### PR TITLE
chore: cleanup dependency tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,6 @@ jobs:
           components: rustfmt
 
       - run: cargo fmt -- --check
-
       - run: cargo clippy -- --deny warnings
 
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,9 @@ jobs:
         with:
           components: rustfmt
 
-      - name: cargo fmt -- --check
-        run: cargo fmt -- --check
+      - run: cargo fmt -- --check
 
-      - name: temporary workaround - fmt all files under src
-        # Workaround for rust-lang/cargo#7732
-        run: cargo fmt -- --check $(find . -name '*.rs' -print)
+      - run: cargo clippy -- --deny warnings
 
   test:
     name: ${{ matrix.name }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ path = "src/lib.rs"
 
 [dependencies]
 futures = "0.3.26"
-libipld = { version = "0.14", default-features = false, features = ["dag-cbor"] }
-multihash = { version = "0.16", default-features = false, features = ["blake2b", "sha2"] }
+libipld = { version = ">=0.14, <0.17", default-features = false, features = ["dag-cbor"] }
+multihash = { version = ">=0.16, <0.19", default-features = false, features = ["blake2b", "sha2"] }
 
 [dev-dependencies]
 async-std = { version = "1.12.0", features = ["attributes"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,20 +15,14 @@ name = "rs_car"
 path = "src/lib.rs"
 
 [dependencies]
-hex = "0.4.3"
 futures = "0.3.26"
-cid = "0.8"
-libipld = "0.14"
-multibase = "0.9.1"
-multihash = "0.16"
-libipld-cbor = "0.14"
-sha2 = "0.10.6"
-multicodec = "0.1.0"
-blake2b_simd = "1.0.1"
+libipld = { version = "0.14", default-features = false, features = ["dag-cbor"] }
+multihash = { version = "0.16", default-features = false, features = ["blake2b", "sha2"] }
 
 [dev-dependencies]
 async-std = { version = "1.12.0", features = ["attributes"] }
+hex = "0.4.3"
 quickcheck = "1.0.3"
 quickcheck_macros = "1.0.0"
-serde = "1.0.152"
+serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"

--- a/src/car_block.rs
+++ b/src/car_block.rs
@@ -1,8 +1,8 @@
-use cid::Cid;
-use futures::{AsyncRead, AsyncReadExt};
 use std::io;
 
-use crate::{block_cid::read_block_cid, error::CarDecodeError, varint::read_varint_u64};
+use futures::{AsyncRead, AsyncReadExt};
+
+use crate::{block_cid::read_block_cid, error::CarDecodeError, varint::read_varint_u64, Cid};
 
 /// Arbitrary high value to prevent big allocations
 const MAX_BLOCK_LEN: u64 = 1073741824;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use cid::Cid;
+use libipld::cid::{self, multihash, Cid};
 
 #[derive(Debug)]
 pub enum CarDecodeError {
@@ -18,7 +18,6 @@ pub enum CarDecodeError {
 
 #[derive(Debug)]
 pub enum HashCode {
-    Name(multicodec::Codec),
     Code(u64),
 }
 

--- a/src/varint.rs
+++ b/src/varint.rs
@@ -15,7 +15,7 @@ pub(crate) async fn read_varint_u64<R: AsyncRead + Unpin>(
         stream.read_exact(&mut buf).await?;
 
         let byte = buf[0];
-        result |= u64::from(byte & 0b0111_1111) << i * 7;
+        result |= u64::from(byte & 0b0111_1111) << (i * 7);
 
         // If is last byte = leftmost bit is zero
         if byte & 0b1000_0000 == 0 {
@@ -24,15 +24,16 @@ pub(crate) async fn read_varint_u64<R: AsyncRead + Unpin>(
     }
 
     // TODO: Return error
-    return Ok(None);
+    Ok(None)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::U64_LEN;
-    use crate::varint::read_varint_u64;
     use futures::io::Cursor;
     use quickcheck_macros::quickcheck;
+
+    use super::U64_LEN;
+    use crate::varint::read_varint_u64;
 
     // Implementation copied from https://github.com/paritytech/unsigned-varint/blob/a3a5b8f2bee1f44270629e96541adf805a53d32c/src/encode.rs#L22
     fn encode_varint_u64(input: u64, buf: &mut [u8; U64_LEN]) -> (&[u8], usize) {

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -38,7 +38,7 @@ macro_rules! error_test {
                         panic!("expected success but got error: {:?}", err)
                     }
                     TestResult::Error(expected_err) => {
-                        assert_eq!(err.to_string(), expected_err)
+                        assert_eq!(err.to_string().replace("kown", "known"), expected_err)
                     }
                 },
                 Err(panic_error) => match $expected {
@@ -58,7 +58,7 @@ macro_rules! error_test {
 error_test!(
     bad_cid_v0,
     "3aa265726f6f747381d8305825000130302030303030303030303030303030303030303030303030303030303030303030306776657273696f6e010130",
-    TestResult::Error("InvalidCarV1Header(\"header cbor codec error: Unkown cbor tag `48`.\")"),
+    TestResult::Error("InvalidCarV1Header(\"header cbor codec error: Unknown cbor tag `48`.\")"),
     TestOptions::None
 );
 
@@ -79,7 +79,7 @@ error_test!(
 error_test!(
     bad_section_length_2,
     "3aa265726f6f747381d8305825000130302030303030303030303030303030303030303030303030303030303030303030306776657273696f6e01200130302030303030303030303030303030303030303030303030303030303030303030303030303030303030",
-    TestResult::Error("InvalidCarV1Header(\"header cbor codec error: Unkown cbor tag `48`.\")"),
+    TestResult::Error("InvalidCarV1Header(\"header cbor codec error: Unknown cbor tag `48`.\")"),
     TestOptions::None
 );
 


### PR DESCRIPTION
This PR tries to keep the dependency tree minimal

Changes:
- Remove `multicodec`which seems to be retired and unmaintained
- Remove `hex`
- Remove `sha2`
- Remove `blake2b_simd`
- Remove `cid`
- Remove `libipld-cbor`
- Remove unused features from `libipld`
- Remove unused features from `multihash`
- Apply `cargo clippy --fix`
- Add `cargo clippy -- --deny warnings` step to CI