### PR TITLE
chore: migrate from `libipld` to `ipld-core`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - name: linux / stable
           - name: linux / beta
             rust: beta
           - name: macOS / stable
@@ -58,13 +59,6 @@ jobs:
             os: windows-latest
             rust: stable-x86_64-pc-windows-gnu
             target: x86_64-pc-windows-gnu
-          # Test multiple versions of libipld in the allowed range
-          - name: linux / stable / 0.16.0
-            libipld_version: "0.16.0"
-          - name: linux / stable / 0.15.0
-            libipld_version: "0.15.0"
-          - name: linux / stable / 0.14.0
-            libipld_version: "0.14.0"
 
     steps:
       - name: Checkout
@@ -76,15 +70,28 @@ jobs:
           toolchain: ${{ matrix.rust || 'stable' }}
           targets: ${{ matrix.target }}
 
-      - name: Set exact dependency
-        if: ${{ matrix.libipld_version }}
-        run: cargo update --package libipld --precise ${{ matrix.libipld_version }}
-
       - name: Check
         run: cargo check
 
       - name: Test
         run: cargo test -- --test-threads=1
+
+  lints:
+    name: Lints
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: cargo fmt
+        run: cargo fmt --check
+
+      - name: cargo clippy
+        run: cargo clippy --all-features --all-targets -- --deny warnings
 
   docs:
     name: Docs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rs-car"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 description = "Rust implementation of the CAR v1 and v2 specifications"
 keywords = ["ipfs", "ipld", "car"]
@@ -15,15 +15,16 @@ name = "rs_car"
 path = "src/lib.rs"
 
 [dependencies]
-futures = "0.3.26"
-libipld = { version = ">=0.14, <0.17", default-features = false, features = ["dag-cbor"] }
-blake2b_simd = { version = "1.0", default-features = false }
+blake2b_simd = { version = "1", default-features = false }
+futures = "0.3"
+ipld-core = { version = "0.4" }
+serde_ipld_dagcbor = { version = "0.6" }
 sha2 = { version = "0.10", default-features = false }
 
 [dev-dependencies]
-async-std = { version = "1.12.0", features = ["attributes"] }
-hex = "0.4.3"
-quickcheck = "1.0.3"
-quickcheck_macros = "1.0.0"
-serde = { version = "1.0.152", features = ["derive"] }
-serde_json = "1.0.93"
+async-std = { version = "1", features = ["attributes"] }
+hex = "0.4"
+quickcheck = "1"
+quickcheck_macros = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/src/carv1_header.rs
+++ b/src/carv1_header.rs
@@ -1,4 +1,5 @@
-use libipld::{cbor::DagCborCodec, cid::Cid, prelude::*, Ipld};
+use ipld_core::{cid::Cid, codec::Codec, ipld::Ipld};
+use serde_ipld_dagcbor::codec::DagCborCodec;
 
 use crate::error::CarDecodeError;
 
@@ -15,7 +16,7 @@ pub(crate) struct CarV1Header {
 /// [varint][DAG-CBOR block][varint|CID|block][varint|CID|block]
 /// ```
 pub(crate) fn decode_carv1_header(header: &[u8]) -> Result<CarV1Header, CarDecodeError> {
-    let header: Ipld = DagCborCodec.decode(header).map_err(|e| {
+    let header: Ipld = DagCborCodec::decode(header).map_err(|e| {
         CarDecodeError::InvalidCarV1Header(format!("header cbor codec error: {e:?}"))
     })?;
 
@@ -100,7 +101,7 @@ mod tests {
         match decode_carv1_header(&header_buf) {
             Err(CarDecodeError::InvalidCarV1Header(str)) => assert_eq!(
                 str,
-                "header cbor codec error: invalid utf-8 sequence of 1 bytes from index 0"
+                "header cbor codec error: DecodeIo(InvalidUtf8(Utf8Error { valid_up_to: 0, error_len: Some(1) }))"
             ),
             x => panic!("other result {:?}", x),
         }
@@ -112,7 +113,7 @@ mod tests {
 
         match decode_carv1_header(&header_buf) {
             Err(CarDecodeError::InvalidCarV1Header(str)) => {
-                assert_eq!(str, "header expected cbor Map but got Integer(0)")
+                assert_eq!(str, "header cbor codec error: DecodeIo(TrailingData)")
             }
             x => panic!("other result {:?}", x),
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use libipld::cid::{self, multihash, Cid};
+use ipld_core::cid::{self, multihash, Cid};
 
 #[derive(Debug)]
 pub enum CarDecodeError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 use futures::{future::BoxFuture, AsyncRead, Stream, StreamExt};
-pub use libipld::cid::Cid;
+pub use ipld_core::cid::Cid;
 
 use crate::{
     block_cid::assert_block_cid,
@@ -195,7 +195,7 @@ mod tests {
 
     type ExpectedCid = HashMap<String, String>;
 
-    fn parse_expected_cids(cids: &Vec<ExpectedCid>) -> Vec<Cid> {
+    fn parse_expected_cids(cids: &[ExpectedCid]) -> Vec<Cid> {
         cids.iter().map(parse_expected_cid).collect()
     }
 

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -3,7 +3,7 @@ use rs_car::car_read_all;
 
 enum TestResult {
     Error(&'static str),
-    Success(&'static str),
+    Success,
 }
 
 #[derive(PartialEq)]
@@ -28,13 +28,13 @@ macro_rules! error_test {
 
             match result {
                 Ok(Ok(_)) => match $expected {
-                    TestResult::Success(_) => {} // Ok
+                    TestResult::Success => {} // Ok
                     TestResult::Error(err) => {
                         panic!("expected error but got success: {:?}", err)
                     }
                 },
                 Ok(Err(err)) => match $expected {
-                    TestResult::Success(_) => {
+                    TestResult::Success => {
                         panic!("expected success but got error: {:?}", err)
                     }
                     TestResult::Error(expected_err) => {
@@ -42,7 +42,7 @@ macro_rules! error_test {
                     }
                 },
                 Err(panic_error) => match $expected {
-                    TestResult::Success(_) => panic!("expected panic but got success"),
+                    TestResult::Success => panic!("expected panic but got success"),
                     TestResult::Error(expected_err) => {
                         panic!(
                             "expected error but got panic: {:?} \n {:?}",
@@ -58,7 +58,7 @@ macro_rules! error_test {
 error_test!(
     bad_cid_v0,
     "3aa265726f6f747381d8305825000130302030303030303030303030303030303030303030303030303030303030303030306776657273696f6e010130",
-    TestResult::Error("InvalidCarV1Header(\"header cbor codec error: Unknown cbor tag `48`.\")"),
+    TestResult::Error("InvalidCarV1Header(\"header cbor codec error: DecodeIo(TypeMismatch { name: \\\"CBOR tag\\\", byte: 48 })\")"),
     TestOptions::None
 );
 
@@ -79,7 +79,7 @@ error_test!(
 error_test!(
     bad_section_length_2,
     "3aa265726f6f747381d8305825000130302030303030303030303030303030303030303030303030303030303030303030306776657273696f6e01200130302030303030303030303030303030303030303030303030303030303030303030303030303030303030",
-    TestResult::Error("InvalidCarV1Header(\"header cbor codec error: Unknown cbor tag `48`.\")"),
+    TestResult::Error("InvalidCarV1Header(\"header cbor codec error: DecodeIo(TypeMismatch { name: \\\"CBOR tag\\\", byte: 48 })\")"),
     TestOptions::None
 );
 
@@ -95,7 +95,7 @@ error_test!(
     bad_block_hash_skip_verify,
 //   header                             cid                                                                          data
     "11a265726f6f7473806776657273696f6e 012e0155122001d448afd928065458cf670b60f5a594d735af0172c8d67f22a81680132681ca ffffffffffffffffffff",
-    TestResult::Success(""),
+    TestResult::Success,
     TestOptions::SkipValidateBlockHash
 );
 


### PR DESCRIPTION
Since `libipld` has been deprecated (see https://github.com/ipld/libipld/pull/198), this PR tries to migrate to `ipld-core`